### PR TITLE
Update README.md for wrong example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,7 @@ var httpHeaders = require('http-headers')
 
 // create TCP server
 net.createServer(function (c) {
-  var buffers = []
-  c.on('data', buffers.push.bind(buffers))
-  c.on('end', function () {
-    var data = Buffer.concat(buffers)
-
+  c.on('data', function (data) {
     // parse incoming data as an HTTP request and extra HTTP headers
     console.log(httpHeaders(data))
   })


### PR DESCRIPTION
The net socket usage is wrong, see: [Event: 'end'](https://nodejs.org/api/net.html#net_event_end)

Socket `end` event is for **FIN** package, that inform client to end connection, not for data receive end.
