### PR TITLE
HTTP/2 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var nextLine = require('next-line')
 // RFC-2068 Start-Line definitions:
 //   Request-Line: Method SP Request-URI SP HTTP-Version CRLF
 //   Status-Line:  HTTP-Version SP Status-Code SP Reason-Phrase CRLF
-var startLine = /^[A-Z_]+(\/\d)?/
+var startLine = /^[A-Z_]+[^:]*$/
 var requestLine = /^([A-Z_]+) (.+) HTTP\/([12](\.(\d))?)$/
 var statusLine = /^HTTP\/([12](\.(\d))?) (\d{3})\s?(.*)?$/
 

--- a/index.js
+++ b/index.js
@@ -17,11 +17,6 @@ function parse (str, onlyHeaders) {
   var line = firstLine(str)
   var match
 
-  //console.log('line', line + '#');
-  console.log('line.match(startLine)', startLine.test(line))
-  //console.log('line.match(statusLine)', line.match(statusLine))
-
-
   if (onlyHeaders && startLine.test(line)) {
     return parseHeaders(str)
   } else if ((match = line.match(requestLine)) !== null) {
@@ -33,7 +28,7 @@ function parse (str, onlyHeaders) {
     }
   } else if ((match = line.match(statusLine)) !== null) {
     return {
-      version: match[1],//{ major: parseInt(match[1], 10), minor: parseInt(match[2], 10) },
+      version: match[1],
       statusCode: parseInt(match[4], 10),
       statusMessage: match[5] ?? '',
       headers: parseHeaders(str)

--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ var nextLine = require('next-line')
 // RFC-2068 Start-Line definitions:
 //   Request-Line: Method SP Request-URI SP HTTP-Version CRLF
 //   Status-Line:  HTTP-Version SP Status-Code SP Reason-Phrase CRLF
-var startLine = /^[A-Z_]+(\/\d\.\d)? /
-var requestLine = /^([A-Z_]+) (.+) [A-Z]+\/(\d)\.(\d)$/
-var statusLine = /^[A-Z]+\/(\d)\.(\d) (\d{3}) (.*)$/
+var startLine = /^[A-Z_]+(\/\d)?/
+var requestLine = /^([A-Z_]+) (.+) HTTP\/([12](\.(\d))?)$/
+var statusLine = /^HTTP\/([12](\.(\d))?) (\d{3})\s?(.*)?$/
 
 module.exports = function (data, onlyHeaders) {
   return parse(normalize(data), onlyHeaders)
@@ -17,20 +17,25 @@ function parse (str, onlyHeaders) {
   var line = firstLine(str)
   var match
 
+  //console.log('line', line + '#');
+  console.log('line.match(startLine)', startLine.test(line))
+  //console.log('line.match(statusLine)', line.match(statusLine))
+
+
   if (onlyHeaders && startLine.test(line)) {
     return parseHeaders(str)
   } else if ((match = line.match(requestLine)) !== null) {
     return {
       method: match[1],
       url: match[2],
-      version: { major: parseInt(match[3], 10), minor: parseInt(match[4], 10) },
+      version: match[3],
       headers: parseHeaders(str)
     }
   } else if ((match = line.match(statusLine)) !== null) {
     return {
-      version: { major: parseInt(match[1], 10), minor: parseInt(match[2], 10) },
-      statusCode: parseInt(match[3], 10),
-      statusMessage: match[4],
+      version: match[1],//{ major: parseInt(match[1], 10), minor: parseInt(match[2], 10) },
+      statusCode: parseInt(match[4], 10),
+      statusMessage: match[5] ?? '',
       headers: parseHeaders(str)
     }
   } else {

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ var nextLine = require('next-line')
 //   Request-Line: Method SP Request-URI SP HTTP-Version CRLF
 //   Status-Line:  HTTP-Version SP Status-Code SP Reason-Phrase CRLF
 var startLine = /^[A-Z_]+[^:]*$/
-var requestLine = /^([A-Z_]+) (.+) HTTP\/([12](\.(\d))?)$/
-var statusLine = /^HTTP\/([12](\.(\d))?) (\d{3})\s?(.*)?$/
+var requestLine = /^([A-Z_]+) (.+) HTTP\/([123](\.(\d))?)$/
+var statusLine = /^HTTP\/([123](\.(\d))?) (\d{3})\s?(.*)?$/
 
 module.exports = function (data, onlyHeaders) {
   return parse(normalize(data), onlyHeaders)

--- a/test.js
+++ b/test.js
@@ -85,7 +85,7 @@ test('start-line + header', function (t) {
   t.deepEqual(httpHeaders(requestLine + msgHeaders, true), headerResult)
   t.deepEqual(httpHeaders(statusLine + msgHeaders, true), headerResult)
   t.deepEqual(httpHeaders(new Buffer(requestLine + msgHeaders), true), headerResult)
-  console.log('checking', statusLine + msgHeaders)
+  
   t.deepEqual(httpHeaders(new Buffer(statusLine + msgHeaders), true), headerResult)
   t.end()
 })
@@ -139,13 +139,12 @@ test('status-line only (HTTP/2)', function (t) {
 test('headers only', function (t) {
   console.log('checking', msgHeaders)
   t.deepEqual(httpHeaders(msgHeaders), headerResult)
-  /*t.deepEqual(httpHeaders(new Buffer(msgHeaders)), headerResult)
+  t.deepEqual(httpHeaders(new Buffer(msgHeaders)), headerResult)
   t.deepEqual(httpHeaders(msgHeaders, true), headerResult)
-  t.deepEqual(httpHeaders(new Buffer(msgHeaders), true), headerResult)*/
+  t.deepEqual(httpHeaders(new Buffer(msgHeaders), true), headerResult)
   t.end()
 })
 
-return;
 
 test('full http response', function (t) {
   t.deepEqual(httpHeaders(requestMsg), requestResult)
@@ -158,6 +157,7 @@ test('full http response', function (t) {
   t.deepEqual(httpHeaders(new Buffer(responseMsg), true), headerResult)
   t.end()
 })
+
 
 test('http.ServerResponse', function (t) {
   t.test('real http.ServerResponse object', function (t) {
@@ -185,6 +185,7 @@ test('http.ServerResponse', function (t) {
     t.end()
   })
 })
+
 
 test('set-cookie', function (t) {
   t.deepEqual(httpHeaders('Set-Cookie: foo'), { 'set-cookie': ['foo'] })

--- a/test.js
+++ b/test.js
@@ -7,6 +7,7 @@ var httpHeaders = require('./')
 
 var requestLine = 'GET /foo HTTP/1.1\r\n'
 var statusLine = 'HTTP/1.1 200 OK\r\n'
+var statusLineV2 = 'HTTP/2 200 \r\n'
 var msgHeaders = 'Date: Tue, 10 Jun 2014 07:29:20 GMT\r\n' +
   'Connection: keep-alive\r\n' +
   'Transfer-Encoding: chunked\r\n' +
@@ -20,6 +21,7 @@ var msgHeaders = 'Date: Tue, 10 Jun 2014 07:29:20 GMT\r\n' +
   '\r\n'
 var requestMsg = requestLine + msgHeaders + 'Hello: World'
 var responseMsg = statusLine + msgHeaders + 'Hello: World'
+var responseMsgV2 = statusLine + msgHeaders + 'Hello: World'
 
 var headerResult = {
   date: 'Tue, 10 Jun 2014 07:29:20 GMT',
@@ -31,15 +33,22 @@ var headerResult = {
   'x-multi-line-header': 'Foo Bar'
 }
 var responseResult = {
-  version: { major: 1, minor: 1 },
+  version: '1.1',
   statusCode: 200,
   statusMessage: 'OK',
   headers: headerResult
 }
+var responseResultV2 = {
+  version: '2',
+  statusCode: 200,
+  statusMessage: '',
+  headers: headerResult
+}
+
 var requestResult = {
   method: 'GET',
   url: '/foo',
-  version: { major: 1, minor: 1 },
+  version: '1.1',
   headers: headerResult
 }
 
@@ -70,11 +79,13 @@ test('empty buffer', function (t) {
 test('start-line + header', function (t) {
   t.deepEqual(httpHeaders(requestLine + msgHeaders), requestResult)
   t.deepEqual(httpHeaders(statusLine + msgHeaders), responseResult)
+  t.deepEqual(httpHeaders(statusLineV2 + msgHeaders), responseResultV2)
   t.deepEqual(httpHeaders(new Buffer(requestLine + msgHeaders)), requestResult)
   t.deepEqual(httpHeaders(new Buffer(statusLine + msgHeaders)), responseResult)
   t.deepEqual(httpHeaders(requestLine + msgHeaders, true), headerResult)
   t.deepEqual(httpHeaders(statusLine + msgHeaders, true), headerResult)
   t.deepEqual(httpHeaders(new Buffer(requestLine + msgHeaders), true), headerResult)
+  console.log('checking', statusLine + msgHeaders)
   t.deepEqual(httpHeaders(new Buffer(statusLine + msgHeaders), true), headerResult)
   t.end()
 })
@@ -83,7 +94,7 @@ test('request-line only', function (t) {
   var requestResult = {
     method: 'GET',
     url: '/foo',
-    version: { major: 1, minor: 1 },
+    version: '1.1',
     headers: {}
   }
 
@@ -96,7 +107,7 @@ test('request-line only', function (t) {
 
 test('status-line only', function (t) {
   var responseResult = {
-    version: { major: 1, minor: 1 },
+    version: '1.1',
     statusCode: 200,
     statusMessage: 'OK',
     headers: {}
@@ -109,13 +120,32 @@ test('status-line only', function (t) {
   t.end()
 })
 
-test('headers only', function (t) {
-  t.deepEqual(httpHeaders(msgHeaders), headerResult)
-  t.deepEqual(httpHeaders(new Buffer(msgHeaders)), headerResult)
-  t.deepEqual(httpHeaders(msgHeaders, true), headerResult)
-  t.deepEqual(httpHeaders(new Buffer(msgHeaders), true), headerResult)
+test('status-line only (HTTP/2)', function (t) {
+  var responseResult = {
+    version: '2',
+    statusCode: 200,
+    statusMessage: '',
+    headers: {}
+  }
+
+  t.deepEqual(httpHeaders(statusLineV2 + '\r\n'), responseResult)
+  t.deepEqual(httpHeaders(new Buffer(statusLineV2 + '\r\n')), responseResult)
+  t.deepEqual(httpHeaders(statusLineV2 + '\r\n', true), {})
+  t.deepEqual(httpHeaders(new Buffer(statusLineV2 + '\r\n'), true), {})
   t.end()
 })
+
+
+test('headers only', function (t) {
+  console.log('checking', msgHeaders)
+  t.deepEqual(httpHeaders(msgHeaders), headerResult)
+  /*t.deepEqual(httpHeaders(new Buffer(msgHeaders)), headerResult)
+  t.deepEqual(httpHeaders(msgHeaders, true), headerResult)
+  t.deepEqual(httpHeaders(new Buffer(msgHeaders), true), headerResult)*/
+  t.end()
+})
+
+return;
 
 test('full http response', function (t) {
   t.deepEqual(httpHeaders(requestMsg), requestResult)


### PR DESCRIPTION
Hey! I needed HTTP/2 support for my project. I also implemented missing text status message according to specs:
https://github.com/whatwg/fetch/issues/599

I emulated curl response in terms of HTTP/2.
https://github.com/curl/curl/issues/1081

I've made sure tests pass through.

One breaking change is that I got rid of major/minor protocol version integers, which I consider to be a bit of over-engineered feature - now the protocol version is just '2' or '1.0' or '1.1' string. This can be easily removed from the PR though, I understand this might be a bad idea to mix such features in one patch.